### PR TITLE
adjust build job to not depend on release anymore

### DIFF
--- a/.github/workflows/continuous-delivery-pipeline.yml
+++ b/.github/workflows/continuous-delivery-pipeline.yml
@@ -66,7 +66,7 @@ jobs:
          path: ${{ matrix.output }}
 
   artifacts:
-    needs: [release, build]
+    needs: build
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 📑 What does this PR do?

The CI job to upload the artifacts to a release is depending on a non-existing job

# ✅ Checklist

 * [x] My pull request adheres to the code style of this project
 * [x] My code requires changes to the documentation
 * [x] I have updated the documentation as required

## 🧪 How can this PR be tested?

Merging this PR to `main` will trigger a CI/CD build and create a new release with artifacts or all platforms

 1. 


## 🧾 Tasks Remaining: (List of tasks remaining to be implemented)

<!--- Add remaining tasks if applicable -->

## 🖼️ Screenshots (if applicable):
